### PR TITLE
[Feat] 가게에 미션추가하기 API

### DIFF
--- a/src/main/java/umc/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/spring/apiPayload/code/status/ErrorStatus.java
@@ -21,9 +21,6 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
 
-    // 예시,,,
-    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다."),
-
     // Ror test
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "이거는 테스트"),
 
@@ -31,7 +28,6 @@ public enum ErrorStatus implements BaseErrorCode {
     FOOD_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "FOOD_CATEGORY4001", "음식 카테고리가 없습니다."),
 
     // Store Error
-
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE_4001","가게가 없습니다.");
 
 

--- a/src/main/java/umc/spring/apiPayload/exception/handler/StoreHandler.java
+++ b/src/main/java/umc/spring/apiPayload/exception/handler/StoreHandler.java
@@ -1,0 +1,10 @@
+package umc.spring.apiPayload.exception.handler;
+
+import umc.spring.apiPayload.code.BaseErrorCode;
+import umc.spring.apiPayload.exception.GeneralException;
+
+public class StoreHandler extends GeneralException {
+    public StoreHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/umc/spring/converter/MissionConverter.java
+++ b/src/main/java/umc/spring/converter/MissionConverter.java
@@ -1,0 +1,13 @@
+package umc.spring.converter;
+
+import umc.spring.domain.Mission;
+import umc.spring.web.dto.MissionResponseDTO;
+
+public class MissionConverter {
+    public static MissionResponseDTO.MissionResultDTO toMissionResultDTO(Mission mission){
+        return MissionResponseDTO.MissionResultDTO.builder()
+                .missionId(mission.getId())
+                .createdAt(mission.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/umc/spring/repository/MissionRepository.java
+++ b/src/main/java/umc/spring/repository/MissionRepository.java
@@ -1,0 +1,7 @@
+package umc.spring.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.spring.domain.Mission;
+
+public interface MissionRepository extends JpaRepository<Mission, Long> {
+}

--- a/src/main/java/umc/spring/repository/StoreRepository.java
+++ b/src/main/java/umc/spring/repository/StoreRepository.java
@@ -1,0 +1,7 @@
+package umc.spring.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.spring.domain.Store;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+}

--- a/src/main/java/umc/spring/service/MissionService/MissionCommandService.java
+++ b/src/main/java/umc/spring/service/MissionService/MissionCommandService.java
@@ -1,0 +1,8 @@
+package umc.spring.service.MissionService;
+
+import umc.spring.domain.Mission;
+import umc.spring.web.dto.MissionRequestDTO;
+
+public interface MissionCommandService {
+    Mission createMission(MissionRequestDTO.MissionCreateDTO request, Long storeId);
+}

--- a/src/main/java/umc/spring/service/MissionService/MissionCommandServiceImpl.java
+++ b/src/main/java/umc/spring/service/MissionService/MissionCommandServiceImpl.java
@@ -1,0 +1,34 @@
+package umc.spring.service.MissionService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.spring.apiPayload.code.status.ErrorStatus;
+import umc.spring.apiPayload.exception.handler.StoreHandler;
+import umc.spring.domain.Mission;
+import umc.spring.domain.Store;
+import umc.spring.repository.MissionRepository;
+import umc.spring.repository.StoreRepository;
+import umc.spring.web.dto.MissionRequestDTO;
+
+@Service
+@RequiredArgsConstructor
+public class MissionCommandServiceImpl implements MissionCommandService{
+    private final MissionRepository missionRepository;
+    private final StoreRepository storeRepository;
+
+    @Override
+    @Transactional
+    public Mission createMission(MissionRequestDTO.MissionCreateDTO request, Long storeId) {
+        Store store = storeRepository.findById(storeId).orElseThrow(() -> new StoreHandler(ErrorStatus.STORE_NOT_FOUND));
+
+        Mission mission = Mission.builder()
+                .reward(request.getReward())
+                .missionSpec(request.getMissionSpec())
+                .deadline(request.getDeadline())
+                .store(store)
+                .build();
+
+        return missionRepository.save(mission);
+    }
+}

--- a/src/main/java/umc/spring/web/controller/MissionRestController.java
+++ b/src/main/java/umc/spring/web/controller/MissionRestController.java
@@ -1,0 +1,25 @@
+package umc.spring.web.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import umc.spring.apiPayload.ApiResponse;
+import umc.spring.converter.MissionConverter;
+import umc.spring.domain.Mission;
+import umc.spring.service.MissionService.MissionCommandService;
+import umc.spring.web.dto.MissionRequestDTO;
+import umc.spring.web.dto.MissionResponseDTO;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/missions")
+public class MissionRestController {
+    private final MissionCommandService missionCommandService;
+
+    @PostMapping("/stores/{storeId}")
+    public ApiResponse<MissionResponseDTO.MissionResultDTO> createMission(@RequestBody MissionRequestDTO.MissionCreateDTO request, @PathVariable(name = "storeId")Long storeId){
+        Mission mission = missionCommandService.createMission(request, storeId);
+
+        return ApiResponse.onSuccess(MissionConverter.toMissionResultDTO(mission));
+
+    }
+}

--- a/src/main/java/umc/spring/web/dto/MissionRequestDTO.java
+++ b/src/main/java/umc/spring/web/dto/MissionRequestDTO.java
@@ -1,0 +1,18 @@
+package umc.spring.web.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+public class MissionRequestDTO {
+    @Getter
+    public static class MissionCreateDTO{
+        @NotNull
+        private Integer reward;
+        @NotNull
+        private LocalDate deadline;
+        @NotNull
+        private String missionSpec;
+    }
+}

--- a/src/main/java/umc/spring/web/dto/MissionResponseDTO.java
+++ b/src/main/java/umc/spring/web/dto/MissionResponseDTO.java
@@ -1,0 +1,19 @@
+package umc.spring.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class MissionResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MissionResultDTO{
+        private Long missionId;
+        private LocalDateTime createdAt;
+    }
+}


### PR DESCRIPTION
# 구현내용
---

store의 id를 받아 해당 가게의 미션 추가하는 API

## MissionCommandService

- storeId에 해당하는 가게가 없을 경우, 에러를 반환하였습니다.

```java
    @Override
    @Transactional
    public Mission createMission(MissionRequestDTO.MissionCreateDTO request, Long storeId) {
        Store store = storeRepository.findById(storeId).orElseThrow(() -> new StoreHandler(ErrorStatus.STORE_NOT_FOUND));

        Mission mission = Mission.builder()
                .reward(request.getReward())
                .missionSpec(request.getMissionSpec())
                .deadline(request.getDeadline())
                .store(store)
                .build();

        return missionRepository.save(mission);
    }
```

</br>

# 데이터베이스
---

```json

  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": {
    "missionId": 1,
    "createdAt": "2024-05-23T23:48:39.1725891"
  }
}
```