### PR TITLE
[Feat] 특정 지역에 가게 추가하기 API

### DIFF
--- a/src/main/java/umc/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/spring/apiPayload/code/status/ErrorStatus.java
@@ -28,7 +28,10 @@ public enum ErrorStatus implements BaseErrorCode {
     FOOD_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "FOOD_CATEGORY4001", "음식 카테고리가 없습니다."),
 
     // Store Error
-    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE_4001","가게가 없습니다.");
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE_4001","가게가 없습니다."),
+
+    // Region Error
+    REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "REGION4001", "해당 지역이 존재하지 않습니다");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/spring/apiPayload/exception/handler/RegionHandler.java
+++ b/src/main/java/umc/spring/apiPayload/exception/handler/RegionHandler.java
@@ -1,0 +1,10 @@
+package umc.spring.apiPayload.exception.handler;
+
+import umc.spring.apiPayload.code.BaseErrorCode;
+import umc.spring.apiPayload.exception.GeneralException;
+
+public class RegionHandler extends GeneralException {
+    public RegionHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/umc/spring/converter/StoreConverter.java
+++ b/src/main/java/umc/spring/converter/StoreConverter.java
@@ -1,0 +1,13 @@
+package umc.spring.converter;
+
+import umc.spring.domain.Store;
+import umc.spring.web.dto.StoreResponseDTO;
+
+public class StoreConverter {
+    public static StoreResponseDTO.StoreResultDTO toStoreResultDTO(Store store){
+        return StoreResponseDTO.StoreResultDTO.builder()
+                .storeId(store.getId())
+                .createdAt(store.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/umc/spring/domain/Mission.java
+++ b/src/main/java/umc/spring/domain/Mission.java
@@ -33,4 +33,8 @@ public class Mission extends BaseEntity {
 
     @OneToMany(mappedBy = "mission", cascade = CascadeType.ALL)
     private List<MemberMission> memberMissionList = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_id")
+    private Region region;
 }

--- a/src/main/java/umc/spring/domain/Region.java
+++ b/src/main/java/umc/spring/domain/Region.java
@@ -4,6 +4,9 @@ import jakarta.persistence.*;
 import lombok.*;
 import umc.spring.domain.common.BaseEntity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -17,4 +20,10 @@ public class Region extends BaseEntity {
 
     @Column(nullable = false, length = 40)
     private String name;
+
+    @OneToMany(mappedBy = "region", cascade = CascadeType.ALL)
+    private List<Store> storeList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "region", cascade = CascadeType.ALL)
+    private List<Mission> missionList = new ArrayList<>();
 }

--- a/src/main/java/umc/spring/domain/Store.java
+++ b/src/main/java/umc/spring/domain/Store.java
@@ -22,4 +22,8 @@ public class Store extends BaseEntity {
     private String address;
 
     private Float score;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_id")
+    private Region region;
 }

--- a/src/main/java/umc/spring/repository/RegionRepository.java
+++ b/src/main/java/umc/spring/repository/RegionRepository.java
@@ -1,0 +1,7 @@
+package umc.spring.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.spring.domain.Region;
+
+public interface RegionRepository extends JpaRepository<Region, Long> {
+}

--- a/src/main/java/umc/spring/service/MissionService/MissionCommandServiceImpl.java
+++ b/src/main/java/umc/spring/service/MissionService/MissionCommandServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import umc.spring.apiPayload.code.status.ErrorStatus;
 import umc.spring.apiPayload.exception.handler.StoreHandler;
 import umc.spring.domain.Mission;
+import umc.spring.domain.Region;
 import umc.spring.domain.Store;
 import umc.spring.repository.MissionRepository;
 import umc.spring.repository.StoreRepository;
@@ -21,12 +22,14 @@ public class MissionCommandServiceImpl implements MissionCommandService{
     @Transactional
     public Mission createMission(MissionRequestDTO.MissionCreateDTO request, Long storeId) {
         Store store = storeRepository.findById(storeId).orElseThrow(() -> new StoreHandler(ErrorStatus.STORE_NOT_FOUND));
+        Region region = store.getRegion();
 
         Mission mission = Mission.builder()
                 .reward(request.getReward())
                 .missionSpec(request.getMissionSpec())
                 .deadline(request.getDeadline())
                 .store(store)
+                .region(region)
                 .build();
 
         return missionRepository.save(mission);

--- a/src/main/java/umc/spring/service/StoreService/StoreCommandService.java
+++ b/src/main/java/umc/spring/service/StoreService/StoreCommandService.java
@@ -1,0 +1,8 @@
+package umc.spring.service.StoreService;
+
+import umc.spring.domain.Store;
+import umc.spring.web.dto.StoreRequestDTO;
+
+public interface StoreCommandService {
+    Store createStore(StoreRequestDTO.StoreInfoDto request, Long regionId);
+}

--- a/src/main/java/umc/spring/service/StoreService/StoreCommandServiceImpl.java
+++ b/src/main/java/umc/spring/service/StoreService/StoreCommandServiceImpl.java
@@ -1,0 +1,30 @@
+package umc.spring.service.StoreService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.spring.apiPayload.code.status.ErrorStatus;
+import umc.spring.apiPayload.exception.handler.RegionHandler;
+import umc.spring.domain.Region;
+import umc.spring.domain.Store;
+import umc.spring.repository.RegionRepository;
+import umc.spring.repository.StoreRepository;
+import umc.spring.web.dto.StoreRequestDTO;
+
+@Service
+@RequiredArgsConstructor
+public class StoreCommandServiceImpl implements StoreCommandService{
+    private final StoreRepository  storeRepository;
+    private final RegionRepository regionRepository;
+
+    @Override
+    public Store createStore(StoreRequestDTO.StoreInfoDto request, Long regionId) {
+        Region region = regionRepository.findById(regionId).orElseThrow(()->new RegionHandler(ErrorStatus.REGION_NOT_FOUND));
+        Store store = Store.builder()
+                .name(request.getName())
+                .address(request.getAddress())
+                .region(region)
+                .build();
+
+        return storeRepository.save(store);
+    }
+}

--- a/src/main/java/umc/spring/web/controller/StoreRestController.java
+++ b/src/main/java/umc/spring/web/controller/StoreRestController.java
@@ -1,0 +1,24 @@
+package umc.spring.web.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import umc.spring.apiPayload.ApiResponse;
+import umc.spring.converter.StoreConverter;
+import umc.spring.domain.Store;
+import umc.spring.service.StoreService.StoreCommandService;
+import umc.spring.web.dto.StoreRequestDTO;
+import umc.spring.web.dto.StoreResponseDTO;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/stores")
+public class StoreRestController {
+    private final StoreCommandService storeCommandService;
+
+    @PostMapping("/regions/{regionId}")
+    public ApiResponse<StoreResponseDTO.StoreResultDTO> createStore(@RequestBody StoreRequestDTO.StoreInfoDto request, @PathVariable(name = "regionId") Long regionId){
+        Store store = storeCommandService.createStore(request, regionId);
+
+        return ApiResponse.onSuccess(StoreConverter.toStoreResultDTO(store));
+    }
+}

--- a/src/main/java/umc/spring/web/dto/StoreRequestDTO.java
+++ b/src/main/java/umc/spring/web/dto/StoreRequestDTO.java
@@ -1,0 +1,14 @@
+package umc.spring.web.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+public class StoreRequestDTO {
+    @Getter
+    public static class StoreInfoDto{
+        @NotNull
+        private String name;
+        @NotNull
+        private String address;
+    }
+}

--- a/src/main/java/umc/spring/web/dto/StoreResponseDTO.java
+++ b/src/main/java/umc/spring/web/dto/StoreResponseDTO.java
@@ -1,0 +1,19 @@
+package umc.spring.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class StoreResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class StoreResultDTO{
+        private Long storeId;
+        private LocalDateTime createdAt;
+    }
+}


### PR DESCRIPTION
# 구현 사항
---

- 지역과 가게 (1:N) 의 매핑 관계를 추가해주었습니다.
- 추가로 지역과 미션(1:N)의 매핑 관계를 추가해주었습니다.

</br>

## StoreCommandServiceImpl

- 지역의 id를 받아 해당 지역에 가게를 추가하도록 구현하였습니다.
- 지역에 해당하는 id가 없으면 에러를 반환합니다.

```java
    @Override
    public Store createStore(StoreRequestDTO.StoreInfoDto request, Long regionId) {
        Region region = regionRepository.findById(regionId).orElseThrow(()->new RegionHandler(ErrorStatus.REGION_NOT_FOUND));
        Store store = Store.builder()
                .name(request.getName())
                .address(request.getAddress())
                .region(region)
                .build();

        return storeRepository.save(store);
    }
```

</br>

## MissionCommandServiceImpl

- 사실 브랜치 따로 파서 수정해야하지만.. 그냥  진행한 부분입니다.
- 가게의 id를 값을  받아 가게 및 가게의 지역을 가져와 두 개 다 저장하였습니다.

```java
    @Override
    @Transactional
    public Mission createMission(MissionRequestDTO.MissionCreateDTO request, Long storeId) {
        Store store = storeRepository.findById(storeId).orElseThrow(() -> new StoreHandler(ErrorStatus.STORE_NOT_FOUND));
        Region region = store.getRegion();

        Mission mission = Mission.builder()
                .reward(request.getReward())
                .missionSpec(request.getMissionSpec())
                .deadline(request.getDeadline())
                .store(store)
                .region(region)
                .build();

        return missionRepository.save(mission);
    }
```

</br>

# 데이터베이스

![image](https://github.com/ROSETERIYAKI/UMC-BE/assets/119154537/36104472-16af-4a51-9f99-880d2fca982d)

