### PR TITLE
[Feat] 가게에 리뷰 추가하기 API

### DIFF
--- a/src/main/java/umc/spring/converter/ReviewConverter.java
+++ b/src/main/java/umc/spring/converter/ReviewConverter.java
@@ -1,0 +1,13 @@
+package umc.spring.converter;
+
+import umc.spring.domain.Review;
+import umc.spring.web.dto.ReviewResponseDTO;
+
+public class ReviewConverter {
+    public static ReviewResponseDTO.ReviewResultDTO toReviewResultDTO(Review review){
+        return ReviewResponseDTO.ReviewResultDTO.builder()
+                .ReviewId(review.getId())
+                .createdAt(review.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/umc/spring/domain/Review.java
+++ b/src/main/java/umc/spring/domain/Review.java
@@ -15,9 +15,6 @@ public class Review extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 20)
-    private String title;
-
     @Column(nullable = false)
     private Float score;
 

--- a/src/main/java/umc/spring/repository/ReviewRepository.java
+++ b/src/main/java/umc/spring/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package umc.spring.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.spring.domain.Review;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/src/main/java/umc/spring/service/ReviewService/ReviewCommandService.java
+++ b/src/main/java/umc/spring/service/ReviewService/ReviewCommandService.java
@@ -1,0 +1,8 @@
+package umc.spring.service.ReviewService;
+
+import umc.spring.domain.Review;
+import umc.spring.web.dto.ReviewRequestDTO;
+
+public interface ReviewCommandService {
+    Review createReview(ReviewRequestDTO.ReviewInfoDTO request, Long storeId);
+}

--- a/src/main/java/umc/spring/service/ReviewService/ReviewCommandServiceImpl.java
+++ b/src/main/java/umc/spring/service/ReviewService/ReviewCommandServiceImpl.java
@@ -1,0 +1,35 @@
+package umc.spring.service.ReviewService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Service;
+import umc.spring.domain.Member;
+import umc.spring.domain.Review;
+import umc.spring.domain.Store;
+import umc.spring.repository.MemberRepository;
+import umc.spring.repository.RegionRepository;
+import umc.spring.repository.ReviewRepository;
+import umc.spring.repository.StoreRepository;
+import umc.spring.web.dto.ReviewRequestDTO;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewCommandServiceImpl implements ReviewCommandService {
+    private final ReviewRepository reviewRepository;
+    private final StoreRepository storeRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public Review createReview(ReviewRequestDTO.ReviewInfoDTO request, Long storeId) {
+        Store store = storeRepository.getReferenceById(storeId);
+
+        Review review = Review.builder()
+                .content(request.getContent())
+                .score(request.getScore())
+                .store(store)
+                .member(memberRepository.getReferenceById(1L))
+                .build();
+
+        return reviewRepository.save(review);
+    }
+}

--- a/src/main/java/umc/spring/service/StoreService/StoreCommandService.java
+++ b/src/main/java/umc/spring/service/StoreService/StoreCommandService.java
@@ -5,4 +5,6 @@ import umc.spring.web.dto.StoreRequestDTO;
 
 public interface StoreCommandService {
     Store createStore(StoreRequestDTO.StoreInfoDto request, Long regionId);
+
+    boolean existsStore(Long storeId);
 }

--- a/src/main/java/umc/spring/service/StoreService/StoreCommandServiceImpl.java
+++ b/src/main/java/umc/spring/service/StoreService/StoreCommandServiceImpl.java
@@ -27,4 +27,10 @@ public class StoreCommandServiceImpl implements StoreCommandService{
 
         return storeRepository.save(store);
     }
+
+    @Override
+    public boolean existsStore(Long storeId) {
+
+        return storeRepository.existsById(storeId);
+    }
 }

--- a/src/main/java/umc/spring/validation/annotation/ExistStore.java
+++ b/src/main/java/umc/spring/validation/annotation/ExistStore.java
@@ -1,0 +1,17 @@
+package umc.spring.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import umc.spring.validation.validator.StoreExistValidator;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = StoreExistValidator.class)
+@Target( {ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistStore {
+    String message() default "해당하는 가게가 존재하지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/umc/spring/validation/validator/StoreExistValidator.java
+++ b/src/main/java/umc/spring/validation/validator/StoreExistValidator.java
@@ -1,0 +1,30 @@
+package umc.spring.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import umc.spring.apiPayload.code.status.ErrorStatus;
+import umc.spring.service.StoreService.StoreCommandService;
+import umc.spring.validation.annotation.ExistStore;
+
+@Component
+@RequiredArgsConstructor
+public class StoreExistValidator implements ConstraintValidator<ExistStore, Long> {
+    private final StoreCommandService storeCommandService;
+    @Override
+    public void initialize(ExistStore constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long value, ConstraintValidatorContext context) {
+        boolean isValid = storeCommandService.existsStore(value);
+
+        if(!isValid){
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.FOOD_CATEGORY_NOT_FOUND.toString()).addConstraintViolation();
+        }
+        return isValid;
+    }
+}

--- a/src/main/java/umc/spring/web/controller/ReviewRestController.java
+++ b/src/main/java/umc/spring/web/controller/ReviewRestController.java
@@ -1,0 +1,25 @@
+package umc.spring.web.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import umc.spring.apiPayload.ApiResponse;
+import umc.spring.converter.ReviewConverter;
+import umc.spring.domain.Review;
+import umc.spring.service.ReviewService.ReviewCommandService;
+import umc.spring.validation.annotation.ExistStore;
+import umc.spring.web.dto.ReviewRequestDTO;
+import umc.spring.web.dto.ReviewResponseDTO;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/reviews")
+public class ReviewRestController {
+    private final ReviewCommandService reviewCommandService;
+
+    @PostMapping("/stores/{storeId}")
+    public ApiResponse<ReviewResponseDTO.ReviewResultDTO> createReview(@RequestBody ReviewRequestDTO.ReviewInfoDTO request,@ExistStore @PathVariable(name = "storeId")Long storeId){
+        Review review = reviewCommandService.createReview(request, storeId);
+
+        return ApiResponse.onSuccess(ReviewConverter.toReviewResultDTO(review));
+    }
+}

--- a/src/main/java/umc/spring/web/dto/ReviewRequestDTO.java
+++ b/src/main/java/umc/spring/web/dto/ReviewRequestDTO.java
@@ -1,0 +1,14 @@
+package umc.spring.web.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+public class ReviewRequestDTO {
+    @Getter
+    public static class ReviewInfoDTO{
+        @NotNull
+        private String content;
+
+        private Float score;
+    }
+}

--- a/src/main/java/umc/spring/web/dto/ReviewResponseDTO.java
+++ b/src/main/java/umc/spring/web/dto/ReviewResponseDTO.java
@@ -1,0 +1,19 @@
+package umc.spring.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class ReviewResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReviewResultDTO{
+        private Long ReviewId;
+        private LocalDateTime createdAt;
+    }
+}


### PR DESCRIPTION
# 구현 설명
---

- 리뷰에 불필요한 필드인 title 삭제
- 가게의 id를 받아 리뷰를 작성하였으며 유저는 1L로 고정

# ReviewCommandServiceImpl

```java
    @Override
    public Review createReview(ReviewRequestDTO.ReviewInfoDTO request, Long storeId) {
        Store store = storeRepository.getReferenceById(storeId);

        Review review = Review.builder()
                .content(request.getContent())
                .score(request.getScore())
                .store(store)
                .member(memberRepository.getReferenceById(1L))
                .build();

        return reviewRepository.save(review);
    }
```

</br>

# 커스텀 어노테이션 작성 (실패)

- 다음과 같이 PathVariable에 넣어놨는데 워크북같은 결과는 안나옴...

```java
    @PostMapping("/stores/{storeId}")
    public ApiResponse<ReviewResponseDTO.ReviewResultDTO> createReview(@RequestBody ReviewRequestDTO.ReviewInfoDTO request,@ExistStore @PathVariable(name = "storeId")Long storeId){
        Review review = reviewCommandService.createReview(request, storeId);

        return ApiResponse.onSuccess(ReviewConverter.toReviewResultDTO(review));
    }
```

</br>

```json
{
  "type": "about:blank",
  "title": "Bad Request",
  "status": 400,
  "detail": "Validation failure",
  "instance": "/reviews/stores/4"
}
```
</BR>

# 데이터베이스

<img width="655" alt="image" src="https://github.com/ROSETERIYAKI/UMC-BE/assets/119154537/9a7590f6-c878-4cff-a458-ca5b8b48cc42">
